### PR TITLE
Detect MIUI by getprop and set max brightness accordingly

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,15 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/cjyyxn/screenfilter/AppConfig.java
+++ b/app/src/main/java/com/cjyyxn/screenfilter/AppConfig.java
@@ -3,11 +3,13 @@ package com.cjyyxn.screenfilter;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 
 @SuppressLint("StaticFieldLeak")
@@ -22,7 +24,29 @@ public class AppConfig {
      * Settings.System.SCREEN_BRIGHTNESS 相关的值
      * 安卓开发者文档中说取值是 0-255
      */
-    public static final int SETTING_SCREEN_BRIGHTNESS = 255;
+    public static final int SETTING_SCREEN_BRIGHTNESS = getSettingScreenBrightness();
+
+    private static String getSystemProperty(String prop) {
+        try {
+            Process p = Runtime.getRuntime().exec("getprop " + prop);
+            try (BufferedReader input = new BufferedReader(new InputStreamReader(p.getInputStream()), 1024)) {
+                return input.readLine();
+            } finally {
+                p.destroy();
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static int getSettingScreenBrightness() {
+        String miui = getSystemProperty("ro.miui.ui.version.name");
+        if (miui != null && !miui.isEmpty()) {
+            return 128;
+        }
+        return 255;
+    }
+
     /**
      * 亮度调节系数，与亮度调节算法有关，取值 [0,1]
      */

--- a/app/src/main/java/com/cjyyxn/screenfilter/AppConfig.java
+++ b/app/src/main/java/com/cjyyxn/screenfilter/AppConfig.java
@@ -21,9 +21,8 @@ public class AppConfig {
     /**
      * Settings.System.SCREEN_BRIGHTNESS 相关的值
      * 安卓开发者文档中说取值是 0-255
-     * 但 MIUI14 中是 1-128
      */
-    public static final int SETTING_SCREEN_BRIGHTNESS = 128;
+    public static final int SETTING_SCREEN_BRIGHTNESS = 255;
     /**
      * 亮度调节系数，与亮度调节算法有关，取值 [0,1]
      */


### PR DESCRIPTION
Try to detect MIUI using `getprop ro.miui.ui.version.name`. #8 

I don't have a Xiaomi device. Not sure if it is working on MIUI, but at least it works on non-MIUI devices, defaulting to 255 max brightness.